### PR TITLE
Remove dependencies: jQuery, Bootstrap, fullScreen.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,67 +6,50 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Hacktoberfest Sign In!!!</title>
-  <!-- JQUERY -->
-  <script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js'></script>
-  <!-- Bootstrap -->
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
-  <!-- JS -->
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fullPage.js/2.9.4/jquery.fullpage.css" />
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/fullPage.js/2.9.4/jquery.fullpage.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/fullPage.js/2.9.4/vendors/scrolloverflow.min.js"></script>
-
+  <!-- normalize.css -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/7.0.0/normalize.min.css">
   <!-- CSS -->
   <link rel="stylesheet" href="main.css">
-
 </head>
 
 <body>
-  <div id="fullpage">
+  <div class="wrapper">
     <!-- Intro Header -->
     <!-- Dont Change This Section -->
-    <div class="section header-bg">
-      <div class="jumbotron-fluid">
+    <div class="section u-text-center u-bg-brand">
+      <div class="section-content jumbotron-fluid u-text-white">
         <h1>Hacktoberfest Pull Request Helper</h1>
         <p class="lead">Your first step towards making a pull request and earning yourself a t-shirt </p>
-        <p class="lead">
-          <a class="btn btn-primary btn-lg" href="https://github.com/nikhilmufc7/Hacktoberfest-PR" target="_blank" rel="noopener noreferrer" role="button">Instructions</a>
-        </p>
+        <a class="btn btn-primary btn-lg" href="https://github.com/nikhilmufc7/Hacktoberfest-PR" target="_blank" rel="noopener noreferrer" role="button">Instructions</a>
       </div>
     </div>
     <!--  -->
 
-    <div class="section center list-grid">
-      <h2></br>October 2017</h2>
+    <div class="section">
+      <div class="section-content u-text-center">
+        <h2>October 2017</h2>
 
-       <!-- SIGN IN HERE -->
-      <ol>
+        <!-- SIGN IN HERE -->
+        <div class="list-grid">
+          <ol>
+            <!--
+              In this format:
+              <li><a href ="[link to your portfolio/github page]">[user name here]</a></li>
+            -->
+            <li><a href="https://github.com/sanghisha145">sanghisha145</a></li>
+            <li><a href="https://github.com/lax91">lax91</a></li>
+            <li><a href="https://github.com/Nikhilmufc7">Nikhilmufc7</a></li>
+            <li><a href="https://github.com/AldoCid">Aldo Cid</a></li>
+            <li><a href="https://github.com/Weeper">Weeper</a></li>
+            <li><a href="https://github.com/MrGlacier/">MrGlacier &#10084;</a></li>
+            <li><a href="https://github.com/ke2ulpatani/">Ketul</a></li>
+          </ol>
+        </div>
+      </div>
 
-        <!--
-                In this format:
-                <li><a href ="[link to your portfolio/github page]">[user name here]</a></li>
-                -->
-
-		<li><a href="https://github.com/sanghisha145">sanghisha145</a></li>                
-                <li><a href="https://github.com/lax91">lax91</a></li>
-                <li><a href="https://github.com/Nikhilmufc7">Nikhilmufc7</a></li>
-                <li><a href="https://github.com/AldoCid">Aldo Cid</a></li>
-                <li><a href="https://github.com/Weeper">Weeper</a></li>
-		<li><a href="https://github.com/MrGlacier/">MrGlacier &#10084;</a></li>
-	      	<li><a href="https://github.com/ke2ulpatani/">Ketul</a></li>
-      </ol>
-
-
-    </div>
-    <!-- End of Oct' 17 Sign in -->
   </div>
-  <!-- Full Page End -->
-  <!-- Script -->
-  <script>
-    $(document).ready(function() {
-      $('#fullpage').fullpage();
-    });
-  </script>
+  <!-- End of Oct' 17 Sign in -->
+</div>
 </body>
 
 </html>

--- a/main.css
+++ b/main.css
@@ -1,45 +1,117 @@
-* {
+/* Base rules */
+:root * {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
+*,
+*:before,
+*:after {
     box-sizing: border-box;
 }
-.center h2{
-    text-align: center;
+
+h2 {
+    font-size: 2.125em;
 }
-.center li{
-    text-align: center;
-}
+
 li {
-    list-style: none;
+    list-style-type: none;
 }
-/* -------- */
-.header-bg{
+
+/* Utility classes */
+.u-text-center {
+    text-align: center;
+}
+
+.u-text-white {
+    color: white;
+}
+
+.u-bg-brand {
     background-color: #489df2;
 }
-.jumbotron-fluid{
-    /* background-color: #f76c5e; */
-    
-    text-align: center;
+
+/* Section */
+.section {
+    display: -webkit-flex;
+    display: -ms-flex;
+    display: flex;
+    align-items: center;
+    height: 100vh;
+    padding-left: 1em;
+    padding-right: 1em;
 }
-.jumbotron-fluid h1{
-    color: white;
-    font-size: 8rem;
-}
-.jumbotron-fluid p{
-    color: white;
-   
-}
-#footer{
-    background-color: blue;
-    text-align: center;
-    color: red;
-    bottom: 0px;
+.section-content {
+    width: 100%;
 }
 
-.list-grid ol{
+/* Jumbotron */
+.jumbotron-fluid h1 {
+    margin-bottom: 0;
+    font-size: 11vmin;
+}
+
+.lead {
+    font-size: 1.25em;
+}
+
+/* Button */
+.btn {
+    display: inline-block;
+    vertical-align: middle;
+    margin-bottom: 0;
+    padding: .4375em .875em;
+    border: 1px solid transparent;
+    border-radius: .25em;
+    line-height: 1.5;
+    text-align: center;
+    text-decoration: none;
+    white-space: nowrap;
+    background-image: none;
+    -ms-touch-action: manipulation;
+    touch-action: manipulation;
+    cursor: pointer;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+.btn-primary {
+    color: white;
+    background-color: rgba(0, 0, 0, .2);
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+    background-color: rgba(0, 0, 0, .4);
+}
+
+.btn-lg {
+    font-size: 1.125em;
+}
+
+/* List grid */
+.list-grid ol {
+    padding: 0;
+}
+
+.list-grid li {
+    line-height: 1.5;
+}
+
+.list-grid a {
+    text-decoration: none;
+    color: #337ab7;
+}
+
+.list-grid a:hover,
+.list-grid a:focus {
+    text-decoration: underline;
+    color: #23527c;
+}
+
+@media only screen and (min-width: 400px) {
+  .list-grid ol {
     column-count: 3;
-}
-
-@media (max-width: 768px) {
-    .jumbotron-fluid h1 {
-        font-size: 4rem;
-    }
+  }
 }


### PR DESCRIPTION
This replaces the above three big dependencies with normalize.css and adds a bit of CSS to get the page back to the original look.
The biggest drawback with this solution is that we don't get the nice transitions from fullPage.js, but I think the filesize savings are worth it.
Also, I used a different font stack, which will show native fonts for macOS and Windows.
Related to #5